### PR TITLE
Fix TypeError in exec1 function when id parameter is None

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,11 +1,17 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 import uvicorn
+from typing import Optional
 
 app = FastAPI()
 
 @app.get("/")
-def exec1(id: int = None):
-    print(id)
+def exec1(id: Optional[int] = None):
+    print(f"Received id: {id}")
+    
+    # Handle None case gracefully
+    if id is None:
+        raise HTTPException(status_code=400, detail="id parameter is required")
+    
     result = 2 + id
     return {"sts": result}
 


### PR DESCRIPTION
## Summary
This PR fixes a critical TypeError that occurs in the `exec1` function when the `id` parameter is None.

## Problem
The original code had a type annotation issue where `id: int = None` allowed None values but attempted arithmetic operations without null checking, causing runtime errors.

**Stack trace:**
```
File "/app/app.py", line 9, in exec1
    result = 2 + id
             ~~^~~~
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

## Changes Made
1. ✅ **Proper Type Annotation**: Changed `id: int = None` to `id: Optional[int] = None`
2. ✅ **Null Safety**: Added explicit None check before arithmetic operation
3. ✅ **Error Handling**: Return HTTP 400 with descriptive error message for None values
4. ✅ **Improved Logging**: Enhanced print statement to show received parameter value
5. ✅ **Import Updates**: Added necessary imports for HTTPException and Optional

## Code Changes
```python
# Before
@app.get("/")
def exec1(id: int = None):
    print(id)
    result = 2 + id  # Crashes when id is None
    return {"sts": result}

# After  
@app.get("/")
def exec1(id: Optional[int] = None):
    print(f"Received id: {id}")
    
    if id is None:
        raise HTTPException(status_code=400, detail="id parameter is required")
        
    result = 2 + id
    return {"sts": result}
```

## Testing
- ✅ Function now handles None values gracefully
- ✅ Returns appropriate HTTP 400 error instead of crashing
- ✅ Maintains existing functionality for valid integer inputs

Fixes #1