### PR TITLE
Fix TypeError in exec1 function: Change id parameter default from None to 0

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,31 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 import uvicorn
 
 app = FastAPI()
 
 @app.get("/")
-def exec1(id: int = None):
-    print(id)
-    result = 2 + id
-    return {"sts": result}
+def exec1(id: int = 0):
+    """
+    Calculate result by adding 2 to the provided id.
+    
+    Args:
+        id (int): Integer value to add to 2. Defaults to 0.
+        
+    Returns:
+        dict: Dictionary containing the calculation result.
+        
+    Raises:
+        HTTPException: If id is not a valid integer.
+    """
+    try:
+        print(f"Received id: {id}")
+        result = 2 + id
+        return {"sts": result}
+    except TypeError as e:
+        raise HTTPException(
+            status_code=400, 
+            detail=f"Invalid input: {str(e)}. Please provide a valid integer for 'id' parameter."
+        )
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", port=8000, log_level="info")


### PR DESCRIPTION
## 概要
FastAPIエンドポイント `/` の `exec1` 関数で発生していたTypeErrorを修正しました。

## 問題
- `id` パラメータのデフォルト値が `None` だったため、`2 + None` でTypeErrorが発生
- エラーハンドリングが不十分で、ユーザーに適切なエラーメッセージが表示されない
- 関数の仕様が不明確でドキュメントが不足

## 修正内容
### 🔧 主要な修正
- ✅ `id` パラメータのデフォルト値を `None` → `0` に変更
- ✅ HTTPExceptionを使った適切なエラーハンドリングを実装
- ✅ 包括的な関数docstringを追加
- ✅ try-catch ブロックでTypeErrorを捕捉・処理
- ✅ ログ出力を改善（フォーマット文字列使用）

### 🧪 テスト可能なケース
- `GET /` → `{"sts": 2}` (id=0のデフォルト)
- `GET /?id=5` → `{"sts": 7}` (正常な計算)
- 無効な値でのエラーハンドリング

### 📝 コード品質向上
- FastAPIのHTTPExceptionを活用
- 型安全性の向上
- エラーメッセージの明確化
- ドキュメント化の改善

## 関連Issue
Fixes #3

## 検証方法
```bash
# サーバー起動
python app.py

# テストケース
curl http://localhost:8000/          # デフォルト値テスト
curl http://localhost:8000/?id=10    # 正常値テスト
```

## チェックリスト
- [x] 問題の根本原因を特定
- [x] 適切なデフォルト値を設定
- [x] エラーハンドリングを実装
- [x] ドキュメントを追加
- [x] コードの可読性を向上