### PR TITLE
Fix TypeError in exec1 function - Replace builtin 'id' with numeric variable

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,8 +5,9 @@ app = FastAPI()
 
 @app.get("/")
 async def exec1():
-    # エラー：idは文字列型の変数だが、数値と加算しようとしている
-    result = 2 + id
+    # 修正：適切な数値変数を使用
+    user_id = 123  # 例として数値を設定
+    result = 2 + user_id
     return {"result": result}
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要
Issue #6 で報告されたTypeErrorを修正しました。

## 変更内容
- `app/app.py` の9行目で発生していたTypeErrorを修正
- Pythonの組み込み関数 `id` を適切な数値変数 `user_id` に変更
- 数値の加算が正常に動作するようになりました

## 修正前
```python
result = 2 + id  # TypeError: unsupported operand type(s)
```

## 修正後
```python
user_id = 123
result = 2 + user_id  # 正常に動作
```

## テスト
- エンドポイント `/` にアクセスして正常にレスポンスが返ることを確認

## 影響範囲
- `/` エンドポイントが正常に動作するようになります
- その他の機能に影響はありません

Fixes #6