### PR TITLE
Fix #8: Replace builtin 'id' with proper variable 'user_id'

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -5,8 +5,9 @@ app = FastAPI()
 
 @app.get("/")
 async def exec1():
-    # エラー：idは文字列型の変数だが、数値と加算しようとしている
-    result = 2 + id
+    # 修正：変数名をuser_idに変更し、適切な数値を設定
+    user_id = 5  # 例として5を設定
+    result = 2 + user_id
     return {"result": result}
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

Issue #8 で報告されたTypeError を修正しました。

## 問題

`app/app.py` の9行目で、Python組み込み関数の `id` を数値と加算しようとしてTypeErrorが発生していました：

```python
result = 2 + id  # TypeError: unsupported operand type(s) for +: 'int' and 'builtin_function_or_method'
```

## 修正内容

- 変数名を `id` から `user_id` に変更
- `user_id` に適切な数値（5）を設定
- これにより `2 + user_id` が正常に動作するようになります

## 修正前
```python
result = 2 + id
```

## 修正後
```python
user_id = 5
result = 2 + user_id
```

## テスト

修正後、FastAPIアプリケーションのルートエンドポイント（"/"）にアクセスすると：
```json
{"result": 7}
```

が正常に返されるはずです。

## 関連Issue

Fixes #8