### PR TITLE
Fix TypeError: Change id parameter default from None to 0

### DIFF
--- a/sample.py
+++ b/sample.py
@@ -4,7 +4,7 @@ import uvicorn
 app = FastAPI()
 
 @app.get("/")
-def exec1(id: int = None):
+def exec1(id: int = 0):
     print(id)
     result = 2 + id
     return {"sts": result}


### PR DESCRIPTION
## 概要
Issue #13で報告されたTypeErrorを修正しました。

## 問題
`exec1`関数で以下のエラーが発生していました：
```
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

## 根本原因
- `id`パラメータのデフォルト値が`None`に設定されていた
- クエリパラメータが渡されない場合に`2 + None`の計算でエラーが発生

## 修正内容
✅ `id`パラメータのデフォルト値を`None`から`0`に変更

### Before:
```python
def exec1(id: int = None):  # ← None causes TypeError
    result = 2 + id
```

### After:
```python  
def exec1(id: int = 0):     # ← Safe default value
    result = 2 + id
```

## テスト方法
1. FastAPIサーバーを起動
2. `GET /` にidパラメータなしでアクセス
3. エラーが発生せず、`{"sts": 2}`が返される
4. `GET /?id=5` にアクセス
5. `{"sts": 7}`が返される

## 影響範囲
- FastAPIの`GET /`エンドポイント
- 既存の動作には影響なし（後方互換性あり）

## チェックリスト
- [x] バグの原因を特定
- [x] 適切な修正を実装
- [x] 既存機能への影響を確認
- [x] コミットメッセージが明確

Closes #13